### PR TITLE
Update PlotDenyListener.java

### DIFF
--- a/src/main/java/com/worldcretornica/plotme_core/listener/PlotDenyListener.java
+++ b/src/main/java/com/worldcretornica/plotme_core/listener/PlotDenyListener.java
@@ -34,7 +34,7 @@ public class PlotDenyListener implements Listener {
                 if (plot != null && plot.isDenied(p.getUniqueId())) {
                     Location to = event.getFrom().clone();
                     to.setYaw(event.getTo().getYaw());
-                    to.setPitch(Event.getTo().getPitch());
+                    to.setPitch(event.getTo().getPitch());
                     event.setTo(to);
                 }
             }


### PR DESCRIPTION
Currently players get stuck on the edge of plots that they are denied from. This change moves them to their previous position instead.
