### PR TITLE
fix Biome names + SQL exception

### DIFF
--- a/src/main/java/com/worldcretornica/plotme_core/PlotMeCoreManager.java
+++ b/src/main/java/com/worldcretornica/plotme_core/PlotMeCoreManager.java
@@ -4,6 +4,7 @@ import com.griefcraft.lwc.LWC;
 import com.griefcraft.model.Protection;
 import com.worldcretornica.plotme_core.api.*;
 import com.worldcretornica.plotme_core.utils.Util;
+import com.worldcretornica.plotme_core.bukkit.api.BukkitBiome;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -588,7 +589,7 @@ public class PlotMeCoreManager {
 
     public void setBiome(IWorld world, String id, IBiome biome) {
         getGenManager(world).setBiome(world, id, biome);
-        plugin.getSqlManager().updatePlot(getIdX(id), getIdZ(id), world.getName(), "biome", biome.toString());
+        plugin.getSqlManager().updatePlot(getIdX(id), getIdZ(id), world.getName(), "biome", ((BukkitBiome)biome).getBiome().name());
     }
 
     public HashSet<UUID> getPlayersIgnoringWELimit() {

--- a/src/main/java/com/worldcretornica/plotme_core/SqlManager.java
+++ b/src/main/java/com/worldcretornica/plotme_core/SqlManager.java
@@ -3,6 +3,7 @@ package com.worldcretornica.plotme_core;
 import com.worldcretornica.plotme_core.api.IPlayer;
 import com.worldcretornica.plotme_core.api.IWorld;
 import com.worldcretornica.plotme_core.utils.UUIDFetcher;
+import com.worldcretornica.plotme_core.bukkit.api.BukkitBiome;
 
 import java.io.File;
 import java.sql.*;
@@ -731,7 +732,7 @@ public class SqlManager {
             ps.setInt(7, topZ);
             //noinspection SuspiciousNameCombination
             ps.setInt(8, bottomZ);
-            ps.setString(9, plot.getBiome().toString());
+            ps.setString(9, ((BukkitBiome)plot.getBiome()).getBiome().name());
             ps.setDate(10, plot.getExpiredDate());
             ps.setBoolean(11, plot.isFinished());
             ps.setDouble(12, plot.getCustomPrice());

--- a/src/main/java/com/worldcretornica/plotme_core/commands/CmdBiome.java
+++ b/src/main/java/com/worldcretornica/plotme_core/commands/CmdBiome.java
@@ -29,6 +29,8 @@ public class CmdBiome extends PlotCommand {
                             player.sendMessage("§c" + args[1] + "§r " + C("MsgIsInvalidBiome"));
                             return true;
                         }
+                        String biomeName = biome.getBiome().name();
+
                         Plot plot = PlotMeCoreManager.getPlotById(id, pmi);
                         String playerName = player.getName();
 
@@ -68,15 +70,15 @@ public class CmdBiome extends PlotCommand {
                                 plugin.getPlotMeCoreManager().setBiome(world, id, biome);
 
                                 double price1 = -price;
-                                player.sendMessage(C("MsgBiomeSet") + " §9" + biome + " " + Util().moneyFormat(price1, true));
+                                player.sendMessage(C("MsgBiomeSet") + " §9" + biomeName + " " + Util().moneyFormat(price1, true));
 
                                 if (isAdvancedLogging()) {
                                     if (price == 0)
                                         serverBridge.getLogger().info(playerName + " " + C("MsgChangedBiome") + " " + id + " " + C("WordTo") + " "
-                                                                              + biome);
+                                                                              + biomeName);
                                     else
                                         serverBridge.getLogger().info(playerName + " " + C("MsgChangedBiome") + " " + id + " " + C("WordTo") + " "
-                                                                              + biome + (" " + C("WordFor") + " " + price));
+                                                                              + biomeName + (" " + C("WordFor") + " " + price));
                                 }
                             }
                         } else {

--- a/src/main/java/com/worldcretornica/plotme_core/commands/CmdInfo.java
+++ b/src/main/java/com/worldcretornica/plotme_core/commands/CmdInfo.java
@@ -7,6 +7,7 @@ import com.worldcretornica.plotme_core.PlotMe_Core;
 import com.worldcretornica.plotme_core.api.ILocation;
 import com.worldcretornica.plotme_core.api.IPlayer;
 import com.worldcretornica.plotme_core.api.IWorld;
+import com.worldcretornica.plotme_core.bukkit.api.BukkitBiome;
 
 public class CmdInfo extends PlotCommand {
 
@@ -26,7 +27,7 @@ public class CmdInfo extends PlotCommand {
                     Plot plot = plugin.getPlotMeCoreManager().getPlotById(id, world);
 
                     player.sendMessage("§aID: §b" + id + "§a " + C("InfoOwner") + ": §b" + plot.getOwner()
-                                               + "§a " + C("InfoBiome") + ": §b" + plot.getBiome());
+                                               + "§a " + C("InfoBiome") + ": §b" + ((BukkitBiome)plot.getBiome()).getBiome().name());
 
                     if (plot.getExpiredDate() == null)
                         if (plot.isFinished())


### PR DESCRIPTION
it was calling `toString` on Biomes at a few places, which returned the whole package name, e.g.
`com.worldcretornica.plotme_core.bukkit.api.BukkitBiome@deadbeef`.

That also resulted in SQL exceptions since the string is longer than the biome column (varchar 32).

This PR should fix that and show the actual Biome name. Thanks to @dico200 again for some help.
