### PR TITLE
add UUID to allowed list

### DIFF
--- a/src/main/java/com/worldcretornica/plotme_core/Plot.java
+++ b/src/main/java/com/worldcretornica/plotme_core/Plot.java
@@ -177,7 +177,7 @@ public class Plot implements Comparable<Plot> {
 
     public void addAllowed(String name, UUID uuid) {
         if (!isAllowedConsulting(name)) {
-            allowed().put(name);
+            allowed().put(name, uuid);
             plugin.getSqlManager().addPlotAllowed(name, uuid, PlotMeCoreManager.getIdX(getId()), PlotMeCoreManager.getIdZ(getId()), getWorld());
         }
     }


### PR DESCRIPTION
This caused `/plot add <player>` to not work because the UUID was stored as null.
Players were only able to build after a restart

---

This took me literally hours to figure. :hankey: 
