### PR TITLE
catch invalid plot number

### DIFF
--- a/src/main/java/com/worldcretornica/plotme_core/commands/CmdHome.java
+++ b/src/main/java/com/worldcretornica/plotme_core/commands/CmdHome.java
@@ -41,7 +41,12 @@ public class CmdHome extends PlotCommand {
                         player.sendMessage(C("WordUsage") + ": §c/plotme home:# §r" + C("WordExample") + ": §c/plotme home:1");
                         return true;
                     } else {
-                        nb = Integer.parseInt(args[0].split(":")[1]);
+                        try {
+                          nb = Integer.parseInt(args[0].split(":")[1]);
+                        } catch (NumberFormatException e) {
+                          player.sendMessage(C("WordUsage") + ": §c/plotme home:# §r" + C("WordExample") + ": §c/plotme home:1");
+                          return true;
+                        }
                     }
                 }
 


### PR DESCRIPTION
catches exception when using e.g. `/plot home:a2`
