### PR TITLE
Add option to configure the speed of progressive plot clearing (NbTicksPerClearStep)

### DIFF
--- a/src/main/java/com/worldcretornica/plotme_core/PlotMeCoreManager.java
+++ b/src/main/java/com/worldcretornica/plotme_core/PlotMeCoreManager.java
@@ -530,6 +530,10 @@ public class PlotMeCoreManager {
         ILocation top = getGenManager(world).getTop(world, id);
 
         if (getMap(worldName).isUseProgressiveClear()) {
+            if (plugin.getPlotLocked(worldName, id) != null) {
+                sender.sendMessage(Util().C("MsgPlotLockedClear"));
+                return;
+            }
             plugin.addPlotToClear(new PlotToClear(worldName, id, reason));
         } else {
             getGenManager(world).clear(bottom, top);

--- a/src/main/java/com/worldcretornica/plotme_core/PlotMe_Core.java
+++ b/src/main/java/com/worldcretornica/plotme_core/PlotMe_Core.java
@@ -203,7 +203,7 @@ public class PlotMe_Core {
         plotsToClear.offer(plotToClear);
 
         Runnable pms = new PlotMeSpool(this, plotToClear);
-        serverBridge.scheduleSyncRepeatingTask(pms, 0L, 200L);
+        serverBridge.scheduleSyncRepeatingTask(pms, 0L, (long) serverBridge.getConfig().getInt("NbTicksPerClearStep", 5));
     }
 
     public void removePlotToClear(PlotToClear plotToClear, int taskid) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,4 +7,5 @@ allowWorldTeleport: true
 defaultWEAnywhere: false
 NbClearSpools: 3
 NbBlocksPerClearStep: 50000
+NbTicksPerClearStep: 5
 AdvancedLogging: false


### PR DESCRIPTION
This provides the ability to configure how frequently the progressive plot clear regenerates a number of blocks (using the NbTicksPerClearStep + Nb option). The current hardcoded amount of 200 ticks is far too long.

For example, this would clear 10000 blocks every 5 ticks:
NbBlocksPerClearStep: 10000
NbTicksPerClearStep: 5

Note: The showProgress method is still called for each clear step, so it can be very verbose. It should be changed to a time based output (might do that later).