### PR TITLE
plotme.unblock.* should not default to true

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -64,7 +64,6 @@ permissions:
         plotme.admin.reload: true
         plotme.admin.middle: true
     plotme.unblock.*:
-      default: true
       description: Unblocks a certain item that was blocked in the config
     plotme.use.middle:
       description: Gives the middle command


### PR DESCRIPTION
This would mean that the ProtectedBlocks list in the config file is useless by default.

Should fix #153 